### PR TITLE
Fixing permissions for installation of dependencies

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -87,8 +87,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          apt-get update
-          apt-get install -y fasttree raxml mafft muscle clustalw clustalo clustalx
+          sudo apt-get update
+          sudo apt-get install -y fasttree raxml mafft muscle clustalw clustalo clustalx
           python -m pip install --upgrade pip
           pip install -e .[mevolib]
 


### PR DESCRIPTION
`test` stage continues failing. This stage should we updated when merging branch with SMoragon/MEvoLib/finished_tests so that `test` stage runs:

```
coverage run -m
pytest -vv  tests/inference/my_test_Inference_*.py
coverage html -d coverage
```